### PR TITLE
ADD: otp verification method support in sdk

### DIFF
--- a/Const.go
+++ b/Const.go
@@ -7,4 +7,5 @@ const (
 	HTTP_TIMEOUT        = 30 * time.Second
 	OIDC_AUTH_TOKEN_API = "https://oidc.otpless.app/auth/userInfo"
 	MAGIC_LINK_URL      = "https://auth.otpless.app/auth/v1/authorize"
+	OTP_BASE_URL        = "https://user-auth.otpless.app/auth/otp"
 )

--- a/OTPlessAuthSdk.go
+++ b/OTPlessAuthSdk.go
@@ -302,7 +302,7 @@ func SendOTP(sendTo, orderID, hash, clientID, clientSecret string) (*SendOTPResp
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("request failed with status code %d", response.StatusCode)
+		return nil, fmt.Errorf("request failed with status code %d %v", response.StatusCode, err)
 	}
 
 	body, err := ioutil.ReadAll(response.Body)

--- a/OTPlessAuthSdk.go
+++ b/OTPlessAuthSdk.go
@@ -301,13 +301,13 @@ func SendOTP(sendTo, orderID, hash, clientID, clientSecret string) (*SendOTPResp
 	}
 	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("request failed with status code %d %v", response.StatusCode, err)
-	}
-
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %v", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request failed with status code %d %v", response.StatusCode, string(body))
 	}
 
 	var otpResponse SendOTPResponse
@@ -352,13 +352,13 @@ func ResendOTP(orderID, clientID, clientSecret string) (*ResendOTPResponse, erro
 	}
 	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("request failed with status code %d", response.StatusCode)
-	}
-
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %v", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request failed with status code %d %v", response.StatusCode, string(body))
 	}
 
 	var otpResponse ResendOTPResponse
@@ -408,6 +408,10 @@ func VerifyOTP(orderID, otp, sendTo, clientID, clientSecret string) (*VerifyOTPR
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %v", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request failed with status code %d %v", response.StatusCode, string(body))
 	}
 
 	var otpResponse VerifyOTPResponse

--- a/OTPlessAuthSdk.go
+++ b/OTPlessAuthSdk.go
@@ -1,6 +1,7 @@
 package otplessAuthSdk
 
 import (
+	"bytes"
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
@@ -263,4 +264,157 @@ func getPublicKey(url string) (map[string]interface{}, error) {
 	}
 
 	return nil, errors.New("Unable to fetch public key")
+}
+
+func SendOTP(sendTo, orderID, hash, clientID, clientSecret string) (*SendOTPResponse, error) {
+	url := OTP_BASE_URL + "/send"
+	headers := map[string]string{
+		"clientId":     clientID,
+		"clientSecret": clientSecret,
+		"Content-Type": "application/json",
+	}
+
+	data := SendOTPRequest{
+		SendTo:  sendTo,
+		OrderID: orderID,
+		Hash:    hash,
+	}
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling data: %v", err)
+	}
+
+	request, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %v", err)
+	}
+
+	for key, value := range headers {
+		request.Header.Set(key, value)
+	}
+
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("error sending request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request failed with status code %d", response.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %v", err)
+	}
+
+	var otpResponse SendOTPResponse
+	err = json.Unmarshal(body, &otpResponse)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling response body: %v", err)
+	}
+
+	return &otpResponse, nil
+}
+
+func ResendOTP(orderID, clientID, clientSecret string) (*ResendOTPResponse, error) {
+	url := OTP_BASE_URL + "/resend"
+	headers := map[string]string{
+		"clientId":     clientID,
+		"clientSecret": clientSecret,
+		"Content-Type": "application/json",
+	}
+
+	data := ResendOTPRequest{
+		OrderID: orderID,
+	}
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling data: %v", err)
+	}
+
+	request, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %v", err)
+	}
+
+	for key, value := range headers {
+		request.Header.Set(key, value)
+	}
+
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("error sending request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request failed with status code %d", response.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %v", err)
+	}
+
+	var otpResponse ResendOTPResponse
+	err = json.Unmarshal(body, &otpResponse)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling response body: %v", err)
+	}
+
+	return &otpResponse, nil
+}
+
+func VerifyOTP(orderID, otp, sendTo, clientID, clientSecret string) (*VerifyOTPResponse, error) {
+	url := OTP_BASE_URL + "/verify"
+	headers := map[string]string{
+		"clientId":     clientID,
+		"clientSecret": clientSecret,
+		"Content-Type": "application/json",
+	}
+
+	data := VerifyOTPRequest{
+		OrderID: orderID,
+		OTP:     otp,
+		SendTo:  sendTo,
+	}
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling data: %v", err)
+	}
+
+	request, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %v", err)
+	}
+
+	for key, value := range headers {
+		request.Header.Set(key, value)
+	}
+
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("error sending request: %v", err)
+	}
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %v", err)
+	}
+
+	var otpResponse VerifyOTPResponse
+	err = json.Unmarshal(body, &otpResponse)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling response body: %v", err)
+	}
+
+	return &otpResponse, nil
 }

--- a/Struct.go
+++ b/Struct.go
@@ -16,3 +16,34 @@ type MagicLinkResponse struct {
 		Value string `json:"value"`
 	} `json:"requestIds"`
 }
+
+type SendOTPRequest struct {
+	SendTo  string `json:"sendTo"`
+	OrderID string `json:"orderId"`
+	Hash    string `json:"hash"`
+}
+
+type SendOTPResponse struct {
+	OrderID string `json:"orderId"`
+	RefID   string `json:"refId"`
+}
+
+type ResendOTPRequest struct {
+	OrderID string `json:"orderId"`
+}
+
+type ResendOTPResponse struct {
+	OrderID string `json:"orderId"`
+	RefID   string `json:"refId"`
+}
+
+type VerifyOTPRequest struct {
+	OrderID string `json:"orderId"`
+	OTP     string `json:"otp"`
+	SendTo  string `json:"sendTo"`
+}
+
+type VerifyOTPResponse struct {
+	IsOTPVerified bool   `json:"isOTPVerified"`
+	Reason        string `json:"reason,omitempty"`
+}


### PR DESCRIPTION
`send otp`

```
package main

import (
	"fmt"

	otplessAuthSdk "github.com/otpless-tech/otpless-auth-sdk"
)

func main() {
	clientID := "your_client_id"
	clientSecret := "your_client_secret"
	sendTo := "919512183993"
	orderID := "VV3"
	hash := "fghxvtascf"

	result, err := otplessAuthSdk.SendOTP(sendTo, orderID, hash, clientID, clientSecret)

	if err != nil {
		fmt.Println("Error:", err)
		return
	}

	fmt.Printf("Result %v %v:", result.OrderID, result.RefID)
}

```

`resend otp`

```
package main

import (
	"fmt"

	otplessAuthSdk "github.com/otpless-tech/otpless-auth-sdk"
)

func main() {
	clientID := "your_client_id"
	clientSecret := "your_client_secret"
	orderID := "VV3"

	result, err := otplessAuthSdk.ResendOTP(orderID, clientID, clientSecret)

	if err != nil {
		fmt.Println("Error:", err)
		return
	}

	fmt.Printf("Result %v %v:", result.OrderID, result.RefID)
}

```

`verify otp`

```
package main

import (
	"fmt"

	otplessAuthSdk "github.com/otpless-tech/otpless-auth-sdk"
)

func main() {
	clientID := "your_client_id"
	clientSecret := "your_client_secret"
	orderID := "VV3"
	otp := "45XXXX52"
	sendTo := "95XXXXXX3"

	result, err := otplessAuthSdk.VerifyOTP(orderID, otp, sendTo, clientID, clientSecret)

	if err != nil {
		fmt.Println("Error:", err)
		return
	}

	fmt.Printf("Result %v:", result.IsOTPVerified)
}

```